### PR TITLE
Execute `kind build node-image` on the remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ This driver was written for the sake of running the tests with [rootless kind](h
 ## Requirements
 - [kubetest2](https://github.com/kubernetes-sigs/kubetest2).
 
-- Docker and [`kind`](https://kind.sigs.k8s.io/) have to be installed on the local host,
-  as the driver executes `kind build node-image` on the local host (currently).
-  The local host can be macOS.
-
 - `gcloud` command has to be configured with the permissions for creating and removing the following resources:
   - GCE Instances
   - VPCs

--- a/deployer/kubetest2-kindinv-provision.sh
+++ b/deployer/kubetest2-kindinv-provision.sh
@@ -5,9 +5,11 @@
 set -eux -o pipefail
 
 # Install dependencies (apt-get)
+# - make:   for `kind build node-image`
+# - uidmap: for rootless
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y uidmap
+apt-get install -y make uidmap
 
 # Install dependencies (snap)
 for f in go kubectl; do


### PR DESCRIPTION
Docker and `kind` no longer need to be present on the local host.

Fix #1